### PR TITLE
Fix encoding & decoding large unsigned u32 & u16 ints in MSSQL.

### DIFF
--- a/sqlx-core/src/mssql/types/int.rs
+++ b/sqlx-core/src/mssql/types/int.rs
@@ -172,7 +172,7 @@ fn decode_numeric(bytes: &[u8], _precision: u8, mut scale: u8) -> Result<i64, Bo
     Ok(n * if negative { -1 } else { 1 })
 }
 
-fn convert_integer<T>(i64_val: i64) -> Result<T, BoxDynError>
+pub(super) fn convert_integer<T>(i64_val: i64) -> Result<T, BoxDynError>
 where
     T: TryFrom<i64>,
     T::Error: std::error::Error + Send + Sync + 'static,

--- a/sqlx-core/src/mssql/types/int.rs
+++ b/sqlx-core/src/mssql/types/int.rs
@@ -30,7 +30,7 @@ impl Encode<'_, Mssql> for i8 {
 impl Decode<'_, Mssql> for i8 {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
         let i64_val = <i64 as Decode<Mssql>>::decode(value)?;
-        convert_integer::<Self>(i64_val)
+        Ok(convert_integer::<u8>(i64_val)? as Self)
     }
 }
 
@@ -58,7 +58,7 @@ impl Encode<'_, Mssql> for i16 {
 impl Decode<'_, Mssql> for i16 {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
         let i64_val = <i64 as Decode<Mssql>>::decode(value)?;
-        convert_integer::<Self>(i64_val)
+        Ok(convert_integer::<u16>(i64_val)? as Self)
     }
 }
 
@@ -83,7 +83,7 @@ impl Encode<'_, Mssql> for i32 {
 impl Decode<'_, Mssql> for i32 {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
         let i64_val = <i64 as Decode<Mssql>>::decode(value)?;
-        convert_integer::<Self>(i64_val)
+        Ok(convert_integer::<u32>(i64_val)? as Self)
     }
 }
 

--- a/sqlx-core/src/mssql/types/uint.rs
+++ b/sqlx-core/src/mssql/types/uint.rs
@@ -43,10 +43,7 @@ impl Type<Mssql> for u16 {
 
 impl Encode<'_, Mssql> for u16 {
     fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
-        let v = i16::try_from(*self).unwrap_or_else(|_e| {
-            log::warn!("cannot encode {self} as a signed mssql smallint");
-            i16::MAX
-        });
+        let v = *self as i16;
         <i16 as Encode<'_, Mssql>>::encode_by_ref(&v, buf)
     }
 }
@@ -70,10 +67,7 @@ impl Type<Mssql> for u32 {
 
 impl Encode<'_, Mssql> for u32 {
     fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
-        let v = i32::try_from(*self).unwrap_or_else(|_e| {
-            log::warn!("cannot encode {self} as a signed mssql int");
-            i32::MAX
-        });
+        let v = *self as i32;
         <i32 as Encode<'_, Mssql>>::encode_by_ref(&v, buf)
     }
 }
@@ -97,10 +91,7 @@ impl Type<Mssql> for u64 {
 
 impl Encode<'_, Mssql> for u64 {
     fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
-        let v = i64::try_from(*self).unwrap_or_else(|_e| {
-            log::warn!("cannot encode {self} as a signed mssql bigint");
-            i64::MAX
-        });
+        let v = *self as i64;
         <i64 as Encode<'_, Mssql>>::encode_by_ref(&v, buf)
     }
 }

--- a/sqlx-core/src/mssql/types/uint.rs
+++ b/sqlx-core/src/mssql/types/uint.rs
@@ -53,8 +53,8 @@ impl Encode<'_, Mssql> for u16 {
 
 impl Decode<'_, Mssql> for u16 {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
-        let v = <i16 as Decode<'_, Mssql>>::decode(value)?;
-        Ok(u16::try_from(v)?)
+        let i64_val = <i64 as Decode<Mssql>>::decode(value)?;
+        super::int::convert_integer::<Self>(i64_val)
     }
 }
 
@@ -80,8 +80,8 @@ impl Encode<'_, Mssql> for u32 {
 
 impl Decode<'_, Mssql> for u32 {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
-        let v = <i32 as Decode<'_, Mssql>>::decode(value)?;
-        Ok(u32::try_from(v)?)
+        let i64_val = <i64 as Decode<Mssql>>::decode(value)?;
+        super::int::convert_integer::<Self>(i64_val)
     }
 }
 


### PR DESCRIPTION
Fixes #14.

As it stands now, it will still die when trying to decode a super big `i64` that's trying to be reinterpreted as a `u64`. Since MSSQL doesn't really have unsigned types, I don't care about that edge case personally, I'm just going to leave it as that.

If someone really wants it, I guess they can just copy the `Decode` implementation for `i64` and swap out the primitive when calling `from_le_bytes`.

https://github.com/sqlpage/sqlx-oldapi/blob/5f0b1fc629c453535655c0249f5fff725b2daedb/sqlx-core/src/mssql/types/int.rs#L146