### PR TITLE
make the subdependency on on aws-lc-rs optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.6.43
  - Fix decoding of small negative unsigned integer in Mssql.
+ - The subdependency on aws-lc-rs (dependency of rustls) is no optional. You can use your own crypto provider (such as ring or openssl) by using the new crate feature `runtime-tokio-rustls-nocrypto` instead of `runtime-tokio-rustls`.
 
 ## 0.6.42
  - Fix `QueryBuilder` for Microsoft SQL Server: https://github.com/sqlpage/sqlx-oldapi/issues/11

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,13 +92,27 @@ runtime-actix-rustls = ["runtime-tokio-rustls"]
 runtime-async-std-rustls = [
     "sqlx-core/runtime-async-std-rustls",
     "sqlx-macros/runtime-async-std-rustls",
+    "aws_lc_rs",
+    "_rt-async-std",
+]
+runtime-async-std-rustls-nocrypto = [
+    "sqlx-core/runtime-async-std-rustls",
+    "sqlx-macros/runtime-async-std-rustls",
     "_rt-async-std",
 ]
 runtime-tokio-rustls = [
     "sqlx-core/runtime-tokio-rustls",
     "sqlx-macros/runtime-tokio-rustls",
+    "aws_lc_rs",
     "_rt-tokio",
 ]
+runtime-tokio-rustls-nocrypto = [
+    "sqlx-core/runtime-tokio-rustls",
+    "sqlx-macros/runtime-tokio-rustls",
+    "_rt-tokio",
+]
+
+aws_lc_rs = ["sqlx-core/aws_lc_rs"]
 
 # for conditional compilation
 _rt-async-std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ runtime-async-std-rustls = [
     "sqlx-core/runtime-async-std-rustls",
     "sqlx-macros/runtime-async-std-rustls",
     "aws_lc_rs",
+    "tls12",
     "_rt-async-std",
 ]
 runtime-async-std-rustls-nocrypto = [
@@ -104,6 +105,7 @@ runtime-tokio-rustls = [
     "sqlx-core/runtime-tokio-rustls",
     "sqlx-macros/runtime-tokio-rustls",
     "aws_lc_rs",
+    "tls12",
     "_rt-tokio",
 ]
 runtime-tokio-rustls-nocrypto = [
@@ -113,6 +115,7 @@ runtime-tokio-rustls-nocrypto = [
 ]
 
 aws_lc_rs = ["sqlx-core/aws_lc_rs"]
+tls12 = ["sqlx-core/tls12"]
 
 # for conditional compilation
 _rt-async-std = []

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -144,7 +144,7 @@ percent-encoding = "2.1.0"
 rand = { version = "0.8", default-features = false, optional = true, features = ["std", "std_rng"] }
 regex = { version = "1.5.5", optional = true }
 rsa = { version = "0.9.2", optional = true }
-rustls = { version = "0.23", optional = true }
+rustls = { version = "0.23", optional = true, default-features = false }
 rustls-pemfile = { version = "2.1", optional = true }
 serde = { version = "1.0.132", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0.73", features = ["raw_value"], optional = true }

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -94,6 +94,7 @@ _rt-tokio = ["tokio-stream", "tokio-util"]
 _tls-native-tls = []
 _tls-rustls = ["rustls", "rustls-pemfile", "webpki-roots"]
 aws_lc_rs = ["rustls/aws_lc_rs", "sqlx-rt/aws_lc_rs"]
+tls12 = ["rustls/tls12"]
 
 # support offline/decoupled building (enables serialization of `Describe`)
 offline = ["serde", "either/serde"]

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -93,6 +93,7 @@ _rt-async-std = []
 _rt-tokio = ["tokio-stream", "tokio-util"]
 _tls-native-tls = []
 _tls-rustls = ["rustls", "rustls-pemfile", "webpki-roots"]
+aws_lc_rs = ["rustls/aws_lc_rs", "sqlx-rt/aws_lc_rs"]
 
 # support offline/decoupled building (enables serialization of `Describe`)
 offline = ["serde", "either/serde"]

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -75,7 +75,7 @@ heck = { version = "0.5" }
 either = "1.6.1"
 once_cell = "1.9.0"
 proc-macro2 = { version = "1.0.36", default-features = false }
-sqlx-core = { package = "sqlx-core-oldapi",  version = "0.6.43", default-features = false, features = ["any", "aws_lc_rs"], path = "../sqlx-core" }
+sqlx-core = { package = "sqlx-core-oldapi",  version = "0.6.43", default-features = false, features = ["any", "aws_lc_rs", "tls12"], path = "../sqlx-core" }
 sqlx-rt = { version = "0.6.43", default-features = false, path = "../sqlx-rt", package = "sqlx-rt-oldapi", features = ["aws_lc_rs"] }
 serde = { version = "1.0.132", features = ["derive"], optional = true }
 serde_json = { version = "1.0.73", optional = true }

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -75,8 +75,8 @@ heck = { version = "0.5" }
 either = "1.6.1"
 once_cell = "1.9.0"
 proc-macro2 = { version = "1.0.36", default-features = false }
-sqlx-core = { package = "sqlx-core-oldapi",  version = "0.6.43", default-features = false, features = ["any"], path = "../sqlx-core" }
-sqlx-rt = { version = "0.6.43", default-features = false, path = "../sqlx-rt", package = "sqlx-rt-oldapi" }
+sqlx-core = { package = "sqlx-core-oldapi",  version = "0.6.43", default-features = false, features = ["any", "aws_lc_rs"], path = "../sqlx-core" }
+sqlx-rt = { version = "0.6.43", default-features = false, path = "../sqlx-rt", package = "sqlx-rt-oldapi", features = ["aws_lc_rs"] }
 serde = { version = "1.0.132", features = ["derive"], optional = true }
 serde_json = { version = "1.0.73", optional = true }
 sha2 = { version = "0.10.0", optional = true }

--- a/sqlx-rt/Cargo.toml
+++ b/sqlx-rt/Cargo.toml
@@ -21,6 +21,7 @@ runtime-tokio-native-tls = ["_rt-tokio", "_tls-native-tls", "tokio-native-tls"]
 runtime-actix-rustls = ["runtime-tokio-rustls"]
 runtime-async-std-rustls = ["_rt-async-std", "_tls-rustls", "futures-rustls"]
 runtime-tokio-rustls = ["_rt-tokio", "_tls-rustls", "tokio-rustls"]
+aws_lc_rs = ["tokio-rustls/aws_lc_rs"]
 
 # Not used directly and not re-exported from sqlx
 _rt-async-std = ["async-std"]

--- a/sqlx-rt/Cargo.toml
+++ b/sqlx-rt/Cargo.toml
@@ -34,7 +34,7 @@ async-native-tls = { version = "0.5.0", optional = true }
 futures-rustls = { version = "0.26", optional = true }
 async-std = { version = "1.7.0", features = ["unstable"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
-tokio-rustls = { version = "0.26", optional = true }
+tokio-rustls = { version = "0.26", optional = true, default-features = false }
 native-tls = { version = "0.2.4", optional = true }
 once_cell = { version = "1.4", features = ["std"], optional = true }
 


### PR DESCRIPTION
- **v0.6.43**
- **remove default features from rustls dependency**
