### PR TITLE
mysql: make pub: MySqlValueRef::format/as_bytes/as_str()

### DIFF
--- a/sqlx-core/src/mssql/value.rs
+++ b/sqlx-core/src/mssql/value.rs
@@ -12,7 +12,7 @@ pub struct MssqlValueRef<'r> {
 }
 
 impl<'r> MssqlValueRef<'r> {
-    pub(crate) fn as_bytes(&self) -> Result<&'r [u8], BoxDynError> {
+    pub fn as_bytes(&self) -> Result<&'r [u8], BoxDynError> {
         match &self.data {
             Some(v) => Ok(v),
             None => Err(UnexpectedNullError.into()),

--- a/sqlx-core/src/mysql/value.rs
+++ b/sqlx-core/src/mysql/value.rs
@@ -31,18 +31,18 @@ pub struct MySqlValueRef<'r> {
 }
 
 impl<'r> MySqlValueRef<'r> {
-    pub(crate) fn format(&self) -> MySqlValueFormat {
+    pub fn format(&self) -> MySqlValueFormat {
         self.format
     }
 
-    pub(crate) fn as_bytes(&self) -> Result<&'r [u8], BoxDynError> {
+    pub fn as_bytes(&self) -> Result<&'r [u8], BoxDynError> {
         match &self.value {
             Some(v) => Ok(v),
             None => Err(UnexpectedNullError.into()),
         }
     }
 
-    pub(crate) fn as_str(&self) -> Result<&'r str, BoxDynError> {
+    pub fn as_str(&self) -> Result<&'r str, BoxDynError> {
         Ok(from_utf8(self.as_bytes()?)?)
     }
 }


### PR DESCRIPTION
I need these methods to be public (well, actually I only need as_bytes) in order to implement custom JSON deserialization. The Postgres driver already allows to get raw values.