### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 >    - Latest SQLite version
 > - Improved support for Microsoft SQL Server, including:
 >     -   Support for reading and writing `binary` and `varbinary` data
->     -   Support for reading and writing `date`, `dateime`, and `datetimeoffset` data using the `chrono` feature.
+>     -   Support for reading and writing `date`, `datetime`, and `datetimeoffset` data using the `chrono` feature.
 >     -   Support for reading and writing `numeric` and `decimal`.
 >     -   Multiple bug fixes around string handling, including better support for long strings
 >     -   Support for packet chunking, which fixes a bug where large bound parameters or large queries would fail


### PR DESCRIPTION
There was a spelling mistake found in your `README.md` file for `dateime` which I've adjusted to be correct (`datetime`).

- Attributed friend sitting next to me while skimming docs 😃