### PR TITLE
Fix odbc column name type mismatch

### DIFF
--- a/sqlx-core/src/odbc/connection/mod.rs
+++ b/sqlx-core/src/odbc/connection/mod.rs
@@ -40,8 +40,11 @@ fn create_column(stmt: &mut PreparedStatement, index: u16) -> OdbcColumn {
     }
 }
 
-fn decode_column_name(name_bytes: Vec<u8>, index: u16) -> String {
-    String::from_utf8(name_bytes).unwrap_or_else(|_| format!("col{}", index - 1))
+fn decode_column_name(name_words: Vec<u16>, index: u16) -> String {
+    match String::from_utf16(&name_words) {
+        Ok(s) => s,
+        Err(_) => format!("col{}", index - 1),
+    }
 }
 
 /// A connection to an ODBC-accessible database.

--- a/sqlx-core/src/odbc/connection/odbc_bridge.rs
+++ b/sqlx-core/src/odbc/connection/odbc_bridge.rs
@@ -139,8 +139,11 @@ where
     }
 }
 
-fn decode_column_name(name_bytes: Vec<u8>, index: u16) -> String {
-    String::from_utf8(name_bytes).unwrap_or_else(|_| format!("col{}", index - 1))
+fn decode_column_name(name_words: Vec<u16>, index: u16) -> String {
+    match String::from_utf16(&name_words) {
+        Ok(s) => s,
+        Err(_) => format!("col{}", index - 1),
+    }
 }
 
 fn stream_rows<C>(cursor: &mut C, columns: &[OdbcColumn], tx: &ExecuteSender) -> Result<bool, Error>


### PR DESCRIPTION
Update `decode_column_name` to accept `Vec<u16>` and decode using `String::from_utf16` to resolve a type mismatch.

---
<a href="https://cursor.com/background-agent?bcId=bc-386d49b6-1ffc-4f37-91b7-1085451ebdf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-386d49b6-1ffc-4f37-91b7-1085451ebdf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

